### PR TITLE
Issue 15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='rac_es',
-    version='0.3',
+    version='0.4',
     description="Helpers for Rockefeller Archive Center's Elasticsearch implementation.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -73,7 +73,7 @@ class TestDocuments(unittest.TestCase):
                     data = json.load(jf)
                     doc = doc_cls(**data)
                     doc.meta.id = data["id"]
-                    doc.save()
+                    doc.save(self.connection)
                     doc_count += 1
                 self.assertEqual(
                     doc.component_reference, "component",
@@ -89,7 +89,7 @@ class TestDocuments(unittest.TestCase):
                 data = json.load(jf)
                 doc = doc_cls(**data)
                 doc.meta.id = data["id"]
-                doc.save()
+                doc.save(self.connection)
 
         self.assertEqual(
             DescriptionComponent.search().count(), total_count,
@@ -105,7 +105,8 @@ class TestDocuments(unittest.TestCase):
                 with open(os.path.join(FIXTURES_DIR, dir, f), "r") as jf:
                     data = json.load(jf)
                     doc = doc_cls(**data)
-                    streaming_dict = doc.prepare_streaming_dict(doc["id"])
+                    streaming_dict = doc.prepare_streaming_dict(
+                        doc["id"], self.connection)
                     self.assertTrue(isinstance(streaming_dict, dict))
                     self.assertEqual(streaming_dict["_id"], doc["id"])
                     self.assertEqual(

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -59,7 +59,7 @@ class TestDocuments(unittest.TestCase):
             expected = self.expected_references(
                 data,
                 set(list(getattr(doc_cls, "relations_in_self", [])) + list(getattr(doc_cls, "relations_to_self", []))))
-            self.assertEqual(len(obj.get_references()),
+            self.assertEqual(len(list(obj.get_references())),
                              expected, (obj.type, obj.meta.id))
 
     def test_document_methods(self):


### PR DESCRIPTION
Use bulk methods to index references in an attempt to speed things up. 

Looked at the `inner_hits` situation, but according to Elasticsearch documentation, that requires a "has_child" query, which is slow and not recommended.

Fixes #15 