### PR TITLE
Loosen requirements versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-elasticsearch=>7.13.0<7.14
-elasticsearch-dsl=>7.3.0<7.4
+elasticsearch==7.13.*
+elasticsearch-dsl==7.3*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 elasticsearch==7.13.*
-elasticsearch-dsl==7.3*
+elasticsearch-dsl==7.3.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-elasticsearch==7.13.0
-elasticsearch-dsl==7.3.0
+elasticsearch=>7.13.0<7.14
+elasticsearch-dsl=>7.3.0<7.4

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,2 @@
-tox==3.23.1
-tox-docker==3.0.0
+tox=>3.23.1<4
+tox-docker=>3.0.0<4

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,2 @@
 tox==3.*
-tox-docker==3*
+tox-docker==3.*

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,2 @@
-tox=>3.23.1<4
-tox-docker=>3.0.0<4
+tox==3.*
+tox-docker==3*


### PR DESCRIPTION
The idea here is to avoid having to release a new version of the library each time a bugfix release comes out, which then means we need to update this dependency in all the apps it's in.