### PR TITLE
Update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
----
-
-sudo: false
 dist: bionic
 
 language: python
@@ -14,12 +11,10 @@ script: tox
 matrix:
   include:
 
-    - python: "3.7"
-      env: TOXENV=py37
+    - python: "3.6"
+      env: TOXENV=py36
 
-    # Linters
-
-    - python: "3.7"
+    - python: "3.6"
       env: TOXENV=linting
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 Helpers for Elasticsearch, including Analyzers and Documents.
 
+[![Build Status](https://travis-ci.org/RockefellerArchiveCenter/rac_es.svg?branch=base)](https://travis-ci.org/RockefellerArchiveCenter/rac_es)
+
 ## Setup
 
 Make sure this library is installed:
 
-    $ pip install git+git://github.com/RockefellerArchiveCenter/rac_es.git
+    $ pip install rac_es
 
 
 ## Usage
@@ -29,6 +31,8 @@ types in the RAC data model: Agents, Collections, Objects and Terms. In addition
 to these definitions, rac_es provides custom search and save methods for these
 Documents, including bulk save and delete methods.
 
+## Development
+This repository contains a configuration file for git [pre-commit](https://pre-commit.com/) hooks which help ensure that code is linted before it is checked into version control. It is strongly recommended that you install these hooks locally by installing pre-commit and running `pre-commit install`.
 
 ## License
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, linting
+envlist = py36, linting
 skipsdist = True
 
 [testenv]
@@ -9,7 +9,7 @@ deps =
   coverage
   pytest
 
-[testenv:py37]
+[testenv:py36]
 docker =
   elasticsearch
 commands =


### PR DESCRIPTION
- Updates README
- Targets Python 3.6 instead of Python 3.7, since that's where it's actually being run.
- Simplify Travis CI configs.

Note there is no `development` branch for this repository because it is not deployed anywhere.